### PR TITLE
OPA-84: Define named constructors for all Backbone extends and set ESLint rule as error

### DIFF
--- a/lib/rules/named-constructor.js
+++ b/lib/rules/named-constructor.js
@@ -52,6 +52,20 @@ module.exports = {
                                 var: node.parent.id.name
                             }
                         );
+
+                    } else if (
+                        node.parent.type === "AssignmentExpression" &&
+                        node.parent.left.type === "Identifier" &&
+                        constructorPropertyNode.value.id.name !== node.parent.left.name
+                    ) {
+                        context.report(
+                            node,
+                            "Constructor name `{{ constructor }}` mismatch the name of local variable `{{ var }}`",
+                            {
+                                constructor: constructorPropertyNode.value.id.name,
+                                var: node.parent.left.name
+                            }
+                        );
                     }
                 }
             }

--- a/tests/lib/rules/named-constructor.js
+++ b/tests/lib/rules/named-constructor.js
@@ -20,6 +20,7 @@ ruleTester.run("named-constructor", rule, {
         "var BazCollection = BaseCollection.extend({ constructor: function BazCollection() { } });",
         "var QuzComponent = BaseComponent.extend({ constructor: function QuzComponent() { } });",
         "var FredClass = QuuxClass.extend({ constructor: function FredClass() { } });",
+        "QeeClass = QuuxClass.extend({ constructor: function QeeClass() { } });",
         "BaseModel.extend({ constructor: function FooModel() { } });"
     ],
 
@@ -39,6 +40,10 @@ ruleTester.run("named-constructor", rule, {
         {
             code: "var FredClass = QuuxClass.extend({ constructor: function BazClass() { } });",
             errors: [{message: "Constructor name `BazClass` mismatch the name of local variable `FredClass`"}]
+        },
+        {
+            code: "QeeClass = QuuxClass.extend({ constructor: function BazClass() { } });",
+            errors: [{message: "Constructor name `BazClass` mismatch the name of local variable `QeeClass`"}]
         }
     ]
 });


### PR DESCRIPTION
 - added check for the variable assignment